### PR TITLE
fix(timestamp): make milliseconds fixed length of 3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -522,7 +522,7 @@ export class Logger {
         }).formatToParts(logObject.date) as IFullDateTimeFormatPart[]),
         {
           type: "millisecond",
-          value: logObject.date.getMilliseconds().toString(),
+          value: logObject.date.getMilliseconds().toFixed(3),
         } as IFullDateTimeFormatPart,
       ];
 


### PR DESCRIPTION
Milliseconds would be converted to a string and have trailing zeroes, making parsing the logs harder.

```diff
diff --git old/old new/new
index 3645e3e..af4e764 100644
--- old/old
+++ new/new
@@ -1,3 +1,3 @@
 2020-09-24 21:24:28.825
-2020-09-24 21:25:10.4
-2020-09-24 21:25:10.91
+2020-09-24 21:25:10.400
+2020-09-24 21:25:10.910
```