### PR TITLE
Make _printPrettyLog public

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,3 +793,20 @@ logger.prettyError(err);
 * `stackOffset` - Offset lines of the stack trace _(default: 0)_
 * `stackLimit`  - Limit number of lines of the stack trace _(default: Infinity)_
 * `std` - Which std should the output be printed to? _(default: stdErr)_
+
+##### printPrettyLog
+Sometimes you just want to _pretty print_ an error on a custom output (if you want to add a new transport for example), e.g.:
+```typescript
+class SimpleStd implements IStd {
+  constructor(private _buffer: string = '') {}
+  write(message: string) {
+    this._buffer += message;
+  }
+
+  get buffer(): string {
+    return this._buffer;
+  }
+}
+```
+
+In those cases, to fill the buffer with the pretty printed log you can just call `logger.printPrettyLog(myStd, myLogObject)` where myStd is an instance of `SimpleStd`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,10 +361,15 @@ export class Logger {
       !this.settings.suppressStdOutput &&
       logObject.logLevelId >= this._logLevels.indexOf(this.settings.minLevel)
     ) {
+      const std: IStd =
+        logObject.logLevelId < this._minLevelToStdErr
+          ? this.settings.stdOut
+          : this.settings.stdErr;
+
       if (this.settings.type === "pretty") {
-        this._printPrettyLog(logObject);
+        this._printPrettyLog(std, logObject);
       } else if (this.settings.type === "json") {
-        this._printJsonLog(logObject);
+        this._printJsonLog(std, logObject);
       } else {
         // don't print (e.g. "hidden")
       }
@@ -504,12 +509,7 @@ export class Logger {
     return stackFrame;
   }
 
-  private _printPrettyLog(logObject: ILogObject): void {
-    const std: IStd =
-      logObject.logLevelId < this._minLevelToStdErr
-        ? this.settings.stdOut
-        : this.settings.stdErr;
-
+  private _printPrettyLog(std: IStd, logObject: ILogObject): void {
     if (this.settings.displayDateTime === true) {
       const dateTimeParts: IFullDateTimeFormatPart[] = [
         ...(new Intl.DateTimeFormat("en", {
@@ -782,12 +782,7 @@ export class Logger {
     };
   }
 
-  private _printJsonLog(logObject: ILogObject): void {
-    const std: IStd =
-      logObject.logLevelId < this._minLevelToStdErr
-        ? this.settings.stdOut
-        : this.settings.stdErr;
-
+  private _printJsonLog(std: IStd, logObject: ILogObject): void {
     std.write(JSON.stringify(logObject) + "\n");
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -367,7 +367,7 @@ export class Logger {
           : this.settings.stdErr;
 
       if (this.settings.type === "pretty") {
-        this._printPrettyLog(std, logObject);
+        this.printPrettyLog(std, logObject);
       } else if (this.settings.type === "json") {
         this._printJsonLog(std, logObject);
       } else {
@@ -509,7 +509,13 @@ export class Logger {
     return stackFrame;
   }
 
-  private _printPrettyLog(std: IStd, logObject: ILogObject): void {
+  /**
+   * Pretty print the log object to the designated output.
+   *
+   * @param std - output where to pretty print the object
+   * @param logObject - object to pretty print
+   **/
+  public printPrettyLog(std: IStd, logObject: ILogObject): void {
     if (this.settings.displayDateTime === true) {
       const dateTimeParts: IFullDateTimeFormatPart[] = [
         ...(new Intl.DateTimeFormat("en", {

--- a/tests/pretty.test.ts
+++ b/tests/pretty.test.ts
@@ -1,5 +1,5 @@
 import "ts-jest";
-import { Logger } from "../src";
+import { IStd, Logger } from "../src";
 import { doesLogContain } from "./helper";
 
 const stdOut: string[] = [];
@@ -125,4 +125,25 @@ test("Pretty circular JSON (stdOut)", (): void => {
   logger.debug(foo);
   expect(doesLogContain(stdOut, "DEBUG")).toBeTruthy();
   expect(doesLogContain(stdOut, "[Circular")).toBeTruthy();
+});
+
+test("Pretty print on custom IStd", (): void => {
+  class SimpleStd implements IStd {
+    constructor(private _buffer: string = "") {}
+    write(message: string) {
+      this._buffer += message;
+    }
+
+    get buffer(): string {
+      return this._buffer;
+    }
+  }
+
+  const testVector = ["this", "is", "a", "test"];
+  const myStd = new SimpleStd();
+  testVector.forEach((e) => logger.printPrettyLog(myStd, logger.debug(e)));
+
+  const logs = myStd.buffer.split(/\r?\n/);
+  expect(logs.length).toBe(testVector.length + 1); // + 1 is for the last EOL
+  logs.forEach((e, i) => expect(e.endsWith(testVector[i] + " ")));
 });


### PR DESCRIPTION
When adding a new transport, I could not find a function parsing an `ILogObject` to a pretty printed string.

It seems that the current `_printPrettyLog` does exactly that: it takes an `ILogObject` and convert it to a nice string. This is useful when you want to add new transports which need to be pretty printed (and which understand ASCII codes).

Hence making this function public will make life a lot easier for us to quickly add new transports to tslog.