### PR TITLE
Fix documentation typo: 'sill' to 'silly'

### DIFF
--- a/docs/tsdoc/globals.html
+++ b/docs/tsdoc/globals.html
@@ -166,7 +166,7 @@
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>Log level names (sill - fatal)</p>
+							<p>Log level names (silly - fatal)</p>
 						</div>
 					</div>
 				</section>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,7 +22,7 @@ export interface ILogLevel {
 export type TLogLevelId = keyof ILogLevel;
 
 /**
- * Log level names (sill - fatal)
+ * Log level names (silly - fatal)
  * @public
  */
 export type TLogLevelName = ILogLevel[TLogLevelId];


### PR DESCRIPTION
Fixed a small typo in the documentation, correcting "sill" to "silly"