### PR TITLE
feat(loggerhelper): skip traverse object payload when there's no maskkey

### DIFF
--- a/src/LoggerHelper.ts
+++ b/src/LoggerHelper.ts
@@ -300,6 +300,10 @@ export class LoggerHelper {
     keys: (number | string)[],
     maskPlaceholder: string
   ): T {
+    if (!Array.isArray(keys) || keys.length === 0) {
+      return obj;
+    }
+
     const fn = (
       key: number | string,
       value: unknown

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -780,6 +780,47 @@ describe("Logger: settings", () => {
     expect(stdStringGroups2?.[3]).toBe("[xxx]");
   });
 
+  test("init logger(type=json): empty maskValuesOfKeys", (): void => {
+    const stdArray: string[] = [];
+    const std: { write: (line: string) => void } = {
+      write: (line: string) => {
+        stdArray.push(line);
+      },
+    };
+    const logger: Logger = new Logger({
+      type: "json",
+      maskValuesOfKeys: [],
+      stdOut: std,
+      stdErr: std,
+    });
+    let verySecretiveCircularObject = {
+      password: "swordfish",
+      Authorization: 1234567,
+      stringPwd: "swordfish",
+      nested: {
+        regularString: "I am just a regular string.",
+        otherString: "pass1234.567",
+      },
+    };
+    verySecretiveCircularObject.nested[
+      "circular"
+    ] = verySecretiveCircularObject;
+
+    const { argumentsArray } = logger.info(verySecretiveCircularObject);
+    expect(argumentsArray[0]).toBe(verySecretiveCircularObject);
+
+    stdArray.length = 0;
+    const undefinedMaskValuesLogger: Logger = new Logger({
+      type: "json",
+      maskValuesOfKeys: undefined,
+      stdOut: std,
+      stdErr: std,
+    });
+
+    const { argumentsArray: undefinedMaskValuesArgArray } = undefinedMaskValuesLogger.info(verySecretiveCircularObject);
+    expect(undefinedMaskValuesArgArray[0]).toBe(verySecretiveCircularObject);
+  });
+
   test("init logger(type=pretty): maskAnyRegEx", (): void => {
     const stdArray: string[] = [];
     const std: { write: (line: string) => void } = {


### PR DESCRIPTION
- relates with #59

**THIS IS NOT A FIX FOR #59** while allows to workaround some of immediate exceptions.

While peeking #59 realized `logObjectMaskValuesOfKeys` traverse payload object regardless of `maskKey` is set or not - even if it's empty array, traverse logic will reassign all of raw values into object property.
This PR adds quick guard to check if there's key specified to be masked - if not, skip object traverse.
