### PR TITLE
fix(getchildlogger): properly returns child logger instance

### DIFF
--- a/src/LoggerWithoutCallSite.ts
+++ b/src/LoggerWithoutCallSite.ts
@@ -200,7 +200,11 @@ export class LoggerWithoutCallSite {
     const childSettings: ISettings = {
       ...this.settings,
     };
-    const childLogger: Logger = new Logger(settings, childSettings);
+    //eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const childLogger: Logger = new (this.constructor as any)(
+      settings,
+      childSettings
+    );
     this._childLogger.push(childLogger);
     return childLogger;
   }


### PR DESCRIPTION
3.0.0 changed https://github.com/fullstack-build/tslog/commit/d4bcdf219bc50f835948b8fc08b6a90f6b45080a# when creating child logger. This is intended in previous code to create proper child based on current instance, otherwise `LoggerWithoutCallSite` will return instance of `Logger` for child logger which defeats tree shaking & behavior of LoggerWithoutCallSite.

Moreover, this creates circular reference dependency between `Logger` to `LoggerWithoutCallSite` (since `LoggerWithoutCallSite` is parent to Logger, re-importing `Logger` in runtime inside `LoggerWithoutCallSite` creates circular imports), raises exception like below:

```
(node:24144) UnhandledPromiseRejectionWarning: ReferenceError: Cannot access 'LoggerWithoutCallSite_LoggerWithoutCallSite' before initialization
    at Module.<anonymous> (C:\github\app\dist\main.bundle.js:2:9358)
    at __webpack_require__ (C:\github\app\dist\main.bundle.js:2:283)
    at Module.<anonymous> (C:\github\app\dist\main.bundle.js:2:1572280)
    at __webpack_require__ (C:\github\app\dist\main.bundle.js:2:283)
    at prepareBoot (C:\github\app\dist\main.bundle.js:2:2252223)
    at Module.<anonymous> (C:\github\app\dist\main.bundle.js:2:2252256)
    at __webpack_require__ (C:\github\app\dist\main.bundle.js:2:283)
    at Object.<anonymous> (C:\github\app\dist\main.bundle.js:2:833729)
    at __webpack_require__ (C:\github\app\dist\main.bundle.js:2:283)
    at C:\github\app\dist\main.bundle.js:2:2773
```