### PR TITLE
Fix broken link to Transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Resulting in the following output:
 
 ##### Forwarded to an attached transport
 
-<a href="#transport">More details below</a>
+<a href="#/?id=transports">More details below</a>
 
 #### Log level
 


### PR DESCRIPTION
Currently, "More details below" leads to 404:
https://tslog.js.org/#/?id=forwarded-to-an-attached-transport