### PR TITLE
Replace Datetime formatting to use hourCycle of h23 instead of hour12

### DIFF
--- a/src/LoggerWithoutCallSite.ts
+++ b/src/LoggerWithoutCallSite.ts
@@ -524,7 +524,7 @@ export class LoggerWithoutCallSite {
             year: "numeric",
             month: "2-digit",
             day: "2-digit",
-            hour12: false,
+            hourCycle: 'h23',
             hour: "2-digit",
             minute: "2-digit",
             second: "2-digit",


### PR DESCRIPTION
With current datetime formatting, 12am (00:xx) hours are displayed as 24:xx

![image](https://user-images.githubusercontent.com/65355029/130831198-152c2f7f-42e8-4b66-9a79-eedb18f7b5e6.png)

By replacing the hour12 options with the newer hourCycle option (available since NodeJS 12.0.0 according to MDN docs)
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#parameters

After replacement, hours are now correctly displayed as 00:xx instead of 24:xx
![image](https://user-images.githubusercontent.com/65355029/130831433-62a925a1-a18f-458a-abd5-5794f592a374.png)

