### PR TITLE
Exclude error name from "IErrorObject"

### DIFF
--- a/src/LoggerWithoutCallSite.ts
+++ b/src/LoggerWithoutCallSite.ts
@@ -456,9 +456,15 @@ export class LoggerWithoutCallSite {
       relevantCallSites.length = stackLimit;
     }
 
+    const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      name: _name,
+      ...errorWithoutName
+    } = error;
+
     const errorObject: IErrorObject = {
       nativeError: error,
-      details: { ...error },
+      details: { ...errorWithoutName },
       name: error.name ?? "Error",
       isError: true,
       message: error.message,

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -55,6 +55,7 @@ describe("Logger: Error with details", () => {
     loggerPretty.warn(error);
     expect(doesLogContain(stdErr, "TestError")).toBeTruthy();
     expect(doesLogContain(stdErr, ".test.ts")).toBeTruthy();
+    expect(doesLogContain(stdErr, "details:")).toBeFalsy();
   });
 
   test("JSON: Error with details (stdErr)", (): void => {
@@ -62,6 +63,7 @@ describe("Logger: Error with details", () => {
     loggerJson.warn(error);
     expect(doesLogContain(stdErr, "TestError")).toBeTruthy();
     expect(doesLogContain(stdErr, ".test.ts")).toBeTruthy();
+    expect(doesLogContain(stdErr, '"details":{}')).toBeTruthy();
   });
 
   test("JSON: Check if call site wrapping is working (Bugfix: #29)", (): void => {


### PR DESCRIPTION
It's redundant to include error name in details (like we're not including other native `Error` properties there), so this PR excludes that property so classes extending `Error` have a cleaner output.

Repro code:
```typescript
import { Logger } from "tslog";
const logger = new Logger();

class CustomError extends Error {
  constructor(message?: string) {
    super(message);
    this.name = "CustomError";
  }
}

logger.error(new CustomError("foo"));
```

Current output:
```
CustomError  foo
details:
{
  name: 'CustomError'
}
error stack:
...
```

Output after this PR:
```
CustomError  foo
error stack:
...
```