### PR TITLE
ensure getCallSites return array

### DIFF
--- a/src/CallSitesHelper.ts
+++ b/src/CallSitesHelper.ts
@@ -78,5 +78,5 @@ Object.defineProperty(Error, "prepareStackTrace", {
 });
 
 export function getCallSites(err: Error): NodeJS.CallSite[] {
-  return err.stack ? err[callsitesSym] : err[callsitesSym];
+  return (err.stack ? err[callsitesSym] : err[callsitesSym]) || [];
 }


### PR DESCRIPTION
I encountered a case using ts log version `3.3.0`, typescript version `4.5.2` and node `v16.13.1`
Where on some errors the getCallSiteHelper will return undefined, and not array.
In such cases the logger will explode the whole server due to the slice operation done in `LoggerHelper.ts:50`
In this minor adjustment I am aligning the helper to respect it's signature, and make sure we always return an array.

```
/workspaces/usr/packages/package-a/dist/node_modules/.pnpm/tslog@3.3.0/node_modules/tslog/src/LoggerHelper.ts:50
      error == null ? getCallSites(new Error()).slice(1) : getCallSites(error);
                                               ^
TypeError: Cannot read properties of undefined (reading 'slice')
    at Function.getCallSites (/workspaces/usr/packages/package-a/dist/node_modules/.pnpm/tslog@3.3.0/node_modules/tslog/src/LoggerHelper.ts:50:48)
```