### PR TITLE
Fix file import extension

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { IMeta, InspectOptions } from "./runtime/nodejs";
+import { IMeta, InspectOptions } from "./runtime/nodejs/index.js";
 
 export type TStyle =
   | null


### PR DESCRIPTION
As node now requires file extensions for relative imports, this is a blocker for using this package for many users.

Currently the following error will be thrown
```
node_modules/.pnpm/tslog@4.4.1/node_modules/tslog/dist/types/interfaces.d.ts:2:39 - error TS2834: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.

2 import { IMeta, InspectOptions } from "./runtime/nodejs";
                                        ~~~~~~~~~~~~~~~~~~
```