### PR TITLE
Add failing test case for missing setters

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,6 @@
     "es2021": true
   },
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
-  "overrides": [],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": "latest",
@@ -16,5 +15,14 @@
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "double"],
     "semi": ["error", "always"]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.cjs"],
+      "rules": {
+        "no-undef": "off",
+        "@typescript-eslint/no-var-requires": "off"
+      }
+    }
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Jest: current file",
+        "program": "${workspaceFolder}/node_modules/.bin/jest",
+        "args": ["${fileBasenameNoExtension}"],
+        "console": "integratedTerminal",
+        "windows": {
+          "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+        }
+      }
+    ]
+  }

--- a/jest-preset.cjs
+++ b/jest-preset.cjs
@@ -1,7 +1,4 @@
-const ts_preset = require('ts-jest/presets/default-esm/jest-preset.js');
-const puppeteer_preset = require('jest-puppeteer/jest-preset.js');
+const ts_preset = require("ts-jest/presets/default-esm/jest-preset.js");
+const puppeteer_preset = require("jest-puppeteer/jest-preset.js");
 
-module.exports = Object.assign(
-    ts_preset,
-    puppeteer_preset
-);
+module.exports = Object.assign(ts_preset, puppeteer_preset);

--- a/jest-puppeteer.config.cjs
+++ b/jest-puppeteer.config.cjs
@@ -1,12 +1,12 @@
 module.exports = {
-    launch: {
-        dumpio: true,
-        headless: process.env.HEADLESS !== 'false',
-    },
-    server: {
-        command: 'npm run test-puppeteer-serve',
-        port: 4444,
-        launchTimeout: 10000,
-        debug: true,
-    },
-}
+  launch: {
+    dumpio: true,
+    headless: process.env.HEADLESS !== "false",
+  },
+  server: {
+    command: "npm run test-puppeteer-serve",
+    port: 4444,
+    launchTimeout: 10000,
+    debug: true,
+  },
+};

--- a/tests/Nodejs/14_Getters_Setters.test.ts
+++ b/tests/Nodejs/14_Getters_Setters.test.ts
@@ -1,0 +1,42 @@
+import { ok } from "assert";
+import "ts-jest";
+import { Logger } from "../../src/index.js";
+import { mockConsoleLog } from "./helper.js";
+
+class MissingSetter {
+  get test(): string {
+    return "test";
+  }
+}
+
+const missingSetter = {
+  get test(): string {
+    return "test";
+  }
+}
+
+describe("Getters and setters", () => {
+  beforeEach(() => {
+    mockConsoleLog(true, false);
+  });
+  test("[class] should not print getters", (): void => {
+    const logger = new Logger({
+      type: "hidden",
+    });
+    const missingSetterObj = new MissingSetter();
+
+    const result = logger.info(missingSetterObj);
+
+    ok(result);
+    Object.keys(result).forEach((key) => {
+      expect(key).not.toBe("test");
+    });
+  });
+  test("[object] should print getters", (): void => {
+    const logger = new Logger({
+      type: "hidden",
+    });
+    const result = logger.info(missingSetter);
+    expect(result).toContain("test");
+  });
+});


### PR DESCRIPTION
This adds a failing test case for #190. This PR intends not to be merged as-is but to be used as the basis of a discussion and to be built upon.

Having the getter being masked is not required to reproduce the issue as `source = (source as string).replace(regEx, this.settings.maskPlaceholder) as T;` is performed regardless of whether the value matches the mask or not. However, if it did match, am not sure what your desired behaviour is as it would certainly run in the issue of not having a setter.

Below is the area of the code that throws the error and one rough possibility for a solution: copy the property bypassing mask. This fails to mask a value when it should have been.

```ts
return isError(source)
      ? source // dont copy Error
      : isBuffer(source)
      ? source // dont copy Buffer
      : Array.isArray(source)
      ? source.map((item) => this._recursiveCloneAndMaskValuesOfKeys(item, keys, seen))
      : source instanceof Date
      ? new Date(source.getTime())
      : source != null && typeof source === "object"
      ? Object.getOwnPropertyNames(source).reduce((o, prop) => {
          const descriptor = Object.getOwnPropertyDescriptor(source, prop);
          Object.defineProperty(o, prop, descriptor!);
          // mask
          if (!descriptor?.set) {
            // copy value over as-is, avoiding mask
          }  else if (keys.includes(this.settings?.maskValuesOfKeysCaseInsensitive !== true ? prop : prop.toLowerCase())) {
            o[prop] = this.settings.maskPlaceholder;
          } else {
            o[prop] = this._recursiveCloneAndMaskValuesOfKeys((source as { [key: string]: unknown })[prop], keys, seen);
          }
          return o;
        }, Object.create(Object.getPrototypeOf(source)))
      : ((source: T): T => {
          // mask regEx
          this.settings?.maskValuesRegEx?.forEach((regEx) => {
            source = (source as string).replace(regEx, this.settings.maskPlaceholder) as T;
          });
          return source;
        })(source);
  }
```


We can identify whether a property has a setter by using:

```ts
const descriptor = Object.getOwnPropertyDescriptor(source, prop);
if (!descriptor?.set) {
}
```

Similarly, what you'd prefer to do in classes vs. objects is unclear. Currently, classes don't print getters. I'd argue that's questionable behaviour due to inconsistency, as objects do (try to) print the getters.

Creating a new object and copying the properties over that have `getters` and assigning it as a normal property would allow the mask to be applied to objects only with getters.