### PR TITLE
Solution for inconveniance using strictly enforced linter and compilers.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { BaseLogger, ILogObjMeta, ISettingsParam, ILogObj } from "./BaseLogger.js";
-export { ISettingsParam, BaseLogger };
+export { ISettingsParam, BaseLogger, ILogObj };
 
 export class Logger<LogObj> extends BaseLogger<LogObj> {
   constructor(settings?: ISettingsParam<LogObj>, logObj?: LogObj) {


### PR DESCRIPTION
When using TSLog with strict type enforcement, linters and compilers will pose problems.

For the compiler, writing : `let logger: Logger;` will trigger an error that wants you to specify which type takes Logger<ILogObj>, we can solve it like that : `let logger: Logger<any>;`

However, this is not satisfying because it will trigger an error in the linter, that we want to specify what that "any" type is. For solving such error we can then export ILogObj definition in index.d.ts to be able to declare correctly our Logger<ILogObj> variables in our strictly enforced code.

Such definition : 
```
import {
     Logger,
     ILogObj
} from "tslog";

let mylogger: Logger<ILogObj>; 
```

Become possible, satisfying both requirement from the compilator and the linter.