### PR TITLE
prevent error in browser's service worker

### DIFF
--- a/src/runtime/browser/index.ts
+++ b/src/runtime/browser/index.ts
@@ -19,7 +19,7 @@ export interface IMeta extends IMetaStatic {
 
 const meta: IMetaStatic = {
   runtime: ![typeof window, typeof document].includes("undefined") ? "Browser" : "Generic",
-  browser: globalThis?.["navigator"]?.userAgent,
+  browser: typeof globalThis === "undefined" ? "" : globalThis?.["navigator"]?.userAgent,
 };
 
 const pathRegex = /(?:(?:file|https?|global code|[^@]+)@)?(?:file:)?((?:\/[^:/]+){2,})(?::(\d+))?(?::(\d+))?/;
@@ -59,7 +59,7 @@ export function getErrorTrace(error: Error): IStackFrame[] {
 }
 
 function stackLineToStackFrame(line?: string): IStackFrame {
-  const href = globalThis.location.origin;
+  const href = typeof globalThis === "undefined" ? "" : globalThis.location.origin;
   const pathResult: IStackFrame = {
     fullFilePath: undefined,
     fileName: undefined,


### PR DESCRIPTION
When `tslog` is run in chrome extensions background service worker, it throws `ReferenceError: window is not defined`. With these two simple checks it's no longer a problem