### PR TITLE
allow for custom placeholders in the template string

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,21 @@ Following settings are available for styling:
   - `prettyErrorLoggerNameDelimiter`: if a logger name is set this delimiter will be added afterwards
   - `prettyInspectOptions`: <a href="https://nodejs.org/api/util.html#utilinspectobject-options" target="_blank">Available options</a>
 
+  ### Customizing template tokens
+  It's possible to add user defined tokes, by overwrting the `addPlaceholders` in the `settings.overwrite`. this callback allows to add or overwrite tokens in the `placeholderValues`.
+  for example, to add the token: {{custom}};
+  ```javascript
+  const logger = new Logger({
+    type: "pretty",
+    prettyLogTemplate: "{{custom}} ",
+    overwrite: {
+      addPlaceholders: (logObjMeta: IMeta, placeholderValues: Record<string, string>) => {
+        placeholderValues["custom"] = "test";
+      },
+    },
+  });
+  ```
+
 - **Styling:**
   - `stylePrettyLogs`: defines whether logs should be styled and colorized
   - `prettyLogStyles`: provides colors and styles for different placeholders and can also be dependent on the value (e.g. log level)

--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Following settings are available for styling:
     },
   });
   ```
+  this would yield in the token {{custom}} being replaced with "test"
 
 - **Styling:**
   - `stylePrettyLogs`: defines whether logs should be styled and colorized

--- a/README.md
+++ b/README.md
@@ -454,8 +454,8 @@ Following settings are available for styling:
   - `prettyInspectOptions`: <a href="https://nodejs.org/api/util.html#utilinspectobject-options" target="_blank">Available options</a>
 
   ### Customizing template tokens
-  It's possible to add user defined tokes, by overwrting the `addPlaceholders` in the `settings.overwrite`. this callback allows to add or overwrite tokens in the `placeholderValues`.
-  for example, to add the token: {{custom}};
+  It's possible to add user defined tokes, by overwriting the `addPlaceholders` in the `settings.overwrite`. this callback allows to add or overwrite tokens in the `placeholderValues`.
+  for example, to add the token: `{{custom}}`;
   ```javascript
   const logger = new Logger({
     type: "pretty",
@@ -467,7 +467,7 @@ Following settings are available for styling:
     },
   });
   ```
-  this would yield in the token {{custom}} being replaced with "test"
+  this would yield in the token `{{custom}}` being replaced with `"test"`
 
 - **Styling:**
   - `stylePrettyLogs`: defines whether logs should be styled and colorized

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>tslog - 📝 Extensible TypeScript Logger for Node.js and Browser: dependency free, fully customizable, pretty errors, stack traces, and JSON output to attachable transports.</title>
+  <title>tslog - 📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="📝 Extensible TypeScript Logger for Node.js and Browser: dependency free, fully customizable, pretty errors, stack traces, and JSON output to attachable transports.">
+  <meta name="description" content="📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>tslog - 📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.</title>
+  <title>tslog - 📝 Extensible TypeScript Logger for Node.js and Browser: dependency free, fully customizable, pretty errors, stack traces, and JSON output to attachable transports.</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.">
+  <meta name="description" content="📝 Extensible TypeScript Logger for Node.js and Browser: dependency free, fully customizable, pretty errors, stack traces, and JSON output to attachable transports.">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
 </head>

--- a/examples/nodejs/index2.ts
+++ b/examples/nodejs/index2.ts
@@ -1,5 +1,7 @@
 import { Logger, BaseLogger } from "../../src/index.js";
 
+import { formatValue } from "../../src/runtime/browser/util.inspect.polyfil";
+
 const defaultLogObject: {
   name: string;
 } = {
@@ -90,3 +92,5 @@ const log = new Logger({
 });
 
 log.info(error);
+
+////////////////////////////

--- a/examples/nodejs/index2.ts
+++ b/examples/nodejs/index2.ts
@@ -109,3 +109,13 @@ const e = createReadonlyError("message", "property");
 logger.error(e);
 
 ///////////////////////////
+
+class CustomError extends Error {
+  constructor(message1: string, message2: string) {
+    super(message1);
+    console.log("***", message1, message2);
+  }
+}
+
+const err = new CustomError("a", "b");
+logger.error(err);

--- a/examples/nodejs/index2.ts
+++ b/examples/nodejs/index2.ts
@@ -70,3 +70,24 @@ const loggerMap = new Logger({ name: 'mapLogger'});
 let map = new Map();
 map.set('foo', 'bar');
 loggerMap.debug('My Map: ', map) // prints in console "DEBUG myLogger My Map: {}"
+
+
+////////////////////////////
+
+const error = new TypeError();
+Object.assign(error, {
+  extensions: {
+    serviceName: 'upstream-service',
+    variables: {
+      firstName: 'foo',
+      phoneNumber: 'bar'
+    }
+  }
+});
+
+const log = new Logger({
+  maskValuesOfKeys: ["firstName", "phoneNumber"],
+  type: "json"
+})
+
+log.info(error);

--- a/examples/nodejs/index2.ts
+++ b/examples/nodejs/index2.ts
@@ -65,29 +65,28 @@ const performanceLogger = new Logger({
 performanceLogger.silly("log without code position information");
 
 ////////////////////////////
-const loggerMap = new Logger({ name: 'mapLogger'});
+const loggerMap = new Logger({ name: "mapLogger" });
 
 let map = new Map();
-map.set('foo', 'bar');
-loggerMap.debug('My Map: ', map) // prints in console "DEBUG myLogger My Map: {}"
-
+map.set("foo", "bar");
+loggerMap.debug("My Map: ", map); // prints in console "DEBUG myLogger My Map: {}"
 
 ////////////////////////////
 
 const error = new TypeError();
 Object.assign(error, {
   extensions: {
-    serviceName: 'upstream-service',
+    serviceName: "upstream-service",
     variables: {
-      firstName: 'foo',
-      phoneNumber: 'bar'
-    }
-  }
+      firstName: "foo",
+      phoneNumber: "bar",
+    },
+  },
 });
 
 const log = new Logger({
   maskValuesOfKeys: ["firstName", "phoneNumber"],
-  type: "json"
-})
+  type: "json",
+});
 
 log.info(error);

--- a/examples/nodejs/index2.ts
+++ b/examples/nodejs/index2.ts
@@ -1,6 +1,4 @@
-import { Logger, BaseLogger } from "../../src/index.js";
-
-import { formatValue } from "../../src/runtime/browser/util.inspect.polyfil";
+import { Logger, BaseLogger, IMeta } from "../../src/index.js";
 
 const defaultLogObject: {
   name: string;
@@ -109,3 +107,5 @@ function createReadonlyError(message: string, property: string) {
 const e = createReadonlyError("message", "property");
 
 logger.error(e);
+
+///////////////////////////

--- a/examples/nodejs/index2.ts
+++ b/examples/nodejs/index2.ts
@@ -94,3 +94,18 @@ const log = new Logger({
 log.info(error);
 
 ////////////////////////////
+
+function createReadonlyError(message: string, property: string) {
+  const error = new Error(message);
+  Object.defineProperty(error, "property", {
+    value: property,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
+  return error;
+}
+
+const e = createReadonlyError("message", "property");
+
+logger.error(e);

--- a/examples/nodejs/index2.ts
+++ b/examples/nodejs/index2.ts
@@ -63,3 +63,10 @@ const performanceLogger = new Logger({
 });
 
 performanceLogger.silly("log without code position information");
+
+////////////////////////////
+const loggerMap = new Logger({ name: 'mapLogger'});
+
+let map = new Map();
+map.set('foo', 'bar');
+loggerMap.debug('My Map: ', map) // prints in console "DEBUG myLogger My Map: {}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tslog",
-  "version": "4.7.4",
+  "version": "4.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tslog",
-      "version": "4.7.4",
+      "version": "4.7.5",
       "license": "MIT",
       "devDependencies": {
         "@jest/types": "^28.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tslog",
-  "version": "4.7.1",
+  "version": "4.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tslog",
-      "version": "4.7.1",
+      "version": "4.7.3",
       "license": "MIT",
       "devDependencies": {
         "@jest/types": "^28.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tslog",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tslog",
-      "version": "4.8.1",
+      "version": "4.8.2",
       "license": "MIT",
       "devDependencies": {
         "@jest/types": "^28.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tslog",
-  "version": "4.7.5",
+  "version": "4.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tslog",
-      "version": "4.7.5",
+      "version": "4.8.0",
       "license": "MIT",
       "devDependencies": {
         "@jest/types": "^28.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tslog",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tslog",
-      "version": "4.8.0",
+      "version": "4.8.1",
       "license": "MIT",
       "devDependencies": {
         "@jest/types": "^28.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tslog",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tslog",
-      "version": "4.7.3",
+      "version": "4.7.4",
       "license": "MIT",
       "devDependencies": {
         "@jest/types": "^28.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslog",
-  "version": "4.7.4",
+  "version": "4.7.5",
   "description": "📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.",
   "author": "Eugene <opensource@terehov.de> (http://fullstack.build/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslog",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "description": "📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.",
   "author": "Eugene <opensource@terehov.de> (http://fullstack.build/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslog",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.",
   "author": "Eugene <opensource@terehov.de> (http://fullstack.build/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslog",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.",
   "author": "Eugene <opensource@terehov.de> (http://fullstack.build/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslog",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "description": "📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.",
   "author": "Eugene <opensource@terehov.de> (http://fullstack.build/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     }
   },
   "scripts": {
+    "prepare": "husky install",
     "build": "npm run build-types && npm run build-server && npm run build-browser",
     "build-browser": "node build.js",
     "build-types": "tsc -b tsconfig.types.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslog",
-  "version": "4.7.5",
+  "version": "4.8.0",
   "description": "📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.",
   "author": "Eugene <opensource@terehov.de> (http://fullstack.build/)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslog",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "📝 Extensible TypeScript Logger for Node.js and Browser: Dependency free, Fully customizable, Pretty errors, stack traces, and JSON output to attachable transports.",
   "author": "Eugene <opensource@terehov.de> (http://fullstack.build/)",
   "license": "MIT",

--- a/src/BaseLogger.ts
+++ b/src/BaseLogger.ts
@@ -70,6 +70,7 @@ export class BaseLogger<LogObj> {
         mask: settings?.overwrite?.mask,
         toLogObj: settings?.overwrite?.toLogObj,
         addMeta: settings?.overwrite?.addMeta,
+        addPlaceholders: settings?.overwrite?.addPlaceholders,
         formatMeta: settings?.overwrite?.formatMeta,
         formatLogObj: settings?.overwrite?.formatLogObj,
         transportFormatted: settings?.overwrite?.transportFormatted,
@@ -276,6 +277,7 @@ export class BaseLogger<LogObj> {
   }
 
   private _cloneError<T extends Error>(error: T): T {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ErrorConstructor = error.constructor as new (...args: any[]) => T;
     const errorProperties = Object.getOwnPropertyNames(error);
     const errorArgs = errorProperties.map((propName) => error[propName]);
@@ -363,6 +365,10 @@ export class BaseLogger<LogObj> {
       placeholderValues["name"].length > 0 ? this.settings.prettyErrorLoggerNameDelimiter + placeholderValues["name"] : "";
     placeholderValues["nameWithDelimiterSuffix"] =
       placeholderValues["name"].length > 0 ? placeholderValues["name"] + this.settings.prettyErrorLoggerNameDelimiter : "";
+
+    if (this.settings.overwrite?.addPlaceholders != null) {
+      this.settings.overwrite?.addPlaceholders(logObjMeta, placeholderValues);
+    }
 
     return formatTemplate(this.settings, template, placeholderValues);
   }

--- a/src/BaseLogger.ts
+++ b/src/BaseLogger.ts
@@ -202,16 +202,16 @@ export class BaseLogger<LogObj> {
 
     return isBuffer(source)
       ? source // dont copy Buffer
-      : source instanceof Map ?
-        new Map(source)
-      : source instanceof Set ?
-        new Set(source)
+      : source instanceof Map
+      ? new Map(source)
+      : source instanceof Set
+      ? new Set(source)
       : Array.isArray(source)
       ? source.map((item) => this._recursiveCloneAndMaskValuesOfKeys(item, keys, seen))
       : source instanceof Date
       ? new Date(source.getTime())
       : isError(source)
-        ? Object.getOwnPropertyNames(source).reduce((o, prop) => {
+      ? Object.getOwnPropertyNames(source).reduce((o, prop) => {
           // mask
           o[prop] = keys.includes(this.settings?.maskValuesOfKeysCaseInsensitive !== true ? prop : prop.toLowerCase())
             ? this.settings.maskPlaceholder

--- a/src/BaseLogger.ts
+++ b/src/BaseLogger.ts
@@ -276,11 +276,14 @@ export class BaseLogger<LogObj> {
   }
 
   private _cloneError<T extends Error>(error: T): T {
-    const ErrorConstructor = error.constructor as new (message?: string) => T;
-    const newError = new ErrorConstructor(error.message);
+    const ErrorConstructor = error.constructor as new (...args: any[]) => T;
+    const errorProperties = Object.getOwnPropertyNames(error);
+    const errorArgs = errorProperties.map((propName) => error[propName]);
+
+    const newError = new ErrorConstructor(...errorArgs);
     Object.assign(newError, error);
-    const propertyNames = Object.getOwnPropertyNames(newError);
-    for (const propName of propertyNames) {
+
+    for (const propName of errorProperties) {
       const propDesc = Object.getOwnPropertyDescriptor(newError, propName);
       if (propDesc) {
         propDesc.writable = true;

--- a/src/BaseLogger.ts
+++ b/src/BaseLogger.ts
@@ -204,6 +204,10 @@ export class BaseLogger<LogObj> {
       ? source // dont copy Error
       : isBuffer(source)
       ? source // dont copy Buffer
+      : source instanceof Map ?
+        new Map(source)
+      : source instanceof Set ?
+        new Set(source)
       : Array.isArray(source)
       ? source.map((item) => this._recursiveCloneAndMaskValuesOfKeys(item, keys, seen))
       : source instanceof Date

--- a/src/BaseLogger.ts
+++ b/src/BaseLogger.ts
@@ -15,7 +15,7 @@ export class BaseLogger<LogObj> {
     const isNode = Object.prototype.toString.call(typeof process !== "undefined" ? process : 0) === "[object process]";
     this.runtime = isBrowser ? "browser" : isNode ? "nodejs" : "unknown";
     const isBrowserBlinkEngine = isBrowser ? ((window?.["chrome"] || (window.Intl && Intl?.["v8BreakIterator"])) && "CSS" in window) != null : false;
-    const isSafari = isBrowser ? /^((?!chrome|android).)*safari/i.test(navigator.userAgent) : false;
+    const isSafari = isBrowser ? /^((?!chrome|android).)*safari/i.test(navigator?.userAgent) : false;
     this.stackDepthLevel = isSafari ? 4 : this.stackDepthLevel;
 
     this.settings = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { BaseLogger, ILogObjMeta, ISettingsParam, ILogObj } from "./BaseLogger.js";
-export { ISettingsParam, BaseLogger, ILogObj };
+import { BaseLogger, ILogObjMeta, ISettingsParam, ILogObj, IMeta } from "./BaseLogger.js";
+export { ISettingsParam, BaseLogger, ILogObj, IMeta };
 
 export class Logger<LogObj> extends BaseLogger<LogObj> {
   constructor(settings?: ISettingsParam<LogObj>, logObj?: LogObj) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -55,6 +55,7 @@ export interface ISettingsParam<LogObj> {
   /**  Array of attached Transports. Use Method `attachTransport` to attach transports. */
   attachedTransports?: ((transportLogger: LogObj & ILogObjMeta) => void)[];
   overwrite?: {
+    addPlaceholders?: (logObjMeta: IMeta, placeholderValues: Record<string, string>) => void;
     mask?: (args: unknown[]) => unknown[];
     toLogObj?: (args: unknown[], clonesLogObj?: LogObj) => LogObj;
     addMeta?: (logObj: LogObj, logLevelId: number, logLevelName: string) => LogObj & ILogObjMeta;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,5 @@
 import { IMeta, InspectOptions } from "./runtime/nodejs/index.js";
+export { IMeta, InspectOptions };
 
 export type TStyle =
   | null

--- a/src/runtime/browser/index.ts
+++ b/src/runtime/browser/index.ts
@@ -6,7 +6,7 @@ import { jsonStringifyRecursive } from "./helper.jsonStringifyRecursive.js";
 export interface IMetaStatic {
   name?: string;
   parentNames?: string[];
-  runtime: string;
+  runtime: "Nodejs" | "Browser" | "Generic";
   browser: string;
 }
 
@@ -18,8 +18,8 @@ export interface IMeta extends IMetaStatic {
 }
 
 const meta: IMetaStatic = {
-  runtime: "Browser",
-  browser: globalThis?.["navigator"].userAgent,
+  runtime: ![typeof window, typeof document].includes("undefined") ? "Browser" : "Generic",
+  browser: globalThis?.["navigator"]?.userAgent,
 };
 
 const pathRegex = /(?:(?:file|https?|global code|[^@]+)@)?(?:file:)?((?:\/[^:/]+){2,})(?::(\d+))?(?::(\d+))?/;

--- a/src/runtime/browser/index.ts
+++ b/src/runtime/browser/index.ts
@@ -19,7 +19,7 @@ export interface IMeta extends IMetaStatic {
 
 const meta: IMetaStatic = {
   runtime: "Browser",
-  browser: window?.["navigator"].userAgent,
+  browser: globalThis?.["navigator"].userAgent,
 };
 
 const pathRegex = /(?:(?:file|https?|global code|[^@]+)@)?(?:file:)?((?:\/[^:/]+){2,})(?::(\d+))?(?::(\d+))?/;
@@ -59,7 +59,7 @@ export function getErrorTrace(error: Error): IStackFrame[] {
 }
 
 function stackLineToStackFrame(line?: string): IStackFrame {
-  const href = window.location.origin;
+  const href = globalThis.location.origin;
   const pathResult: IStackFrame = {
     fullFilePath: undefined,
     fileName: undefined,

--- a/src/runtime/browser/util.inspect.polyfil.ts
+++ b/src/runtime/browser/util.inspect.polyfil.ts
@@ -150,7 +150,7 @@ function formatError(value: Error): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function formatValue(ctx: ICtx, value: any, recurseTimes = 0): string {
+export function formatValue(ctx: ICtx, value: any, recurseTimes = 0): string {
   // Provide a hook for user-specified inspect functions.
   // Check that value is an object with an inspect function on it
   if (
@@ -162,6 +162,9 @@ function formatValue(ctx: ICtx, value: any, recurseTimes = 0): string {
     // Also filter out any prototype objects using the circular check.
     !(value?.constructor && value?.constructor.prototype === value)
   ) {
+    if (typeof value.inspect !== "function" && value.toString != null) {
+      return value.toString();
+    }
     let ret = value?.inspect(recurseTimes, ctx);
     if (!isString(ret)) {
       ret = formatValue(ctx, ret, recurseTimes);
@@ -194,18 +197,22 @@ function formatValue(ctx: ICtx, value: any, recurseTimes = 0): string {
 
   // Some type of object without properties can be shortcutted.
   if (keys.length === 0) {
-    if (isFunction(value)) {
-      const name = value.name ? ": " + value.name : "";
-      return ctx.stylize("[Function" + name + "]", "special");
-    }
-    if (isRegExp(value)) {
-      return ctx.stylize(RegExp.prototype.toString.call(value), "regexp");
-    }
-    if (isDate(value)) {
-      return ctx.stylize(Date.prototype.toString.call(value), "date");
-    }
-    if (isError(value)) {
-      return formatError(value as Error);
+    if (isFunction(ctx.stylize)) {
+      if (isFunction(value)) {
+        const name = value.name ? ": " + value.name : "";
+        return ctx.stylize("[Function" + name + "]", "special");
+      }
+      if (isRegExp(value)) {
+        return ctx.stylize(RegExp.prototype.toString.call(value), "regexp");
+      }
+      if (isDate(value)) {
+        return ctx.stylize(Date.prototype.toString.call(value), "date");
+      }
+      if (isError(value)) {
+        return formatError(value as Error);
+      }
+    } else {
+      return value;
     }
   }
 

--- a/tests/Nodejs/15_Placeholders.test.ts
+++ b/tests/Nodejs/15_Placeholders.test.ts
@@ -1,0 +1,24 @@
+import "ts-jest";
+import { IMeta, Logger } from "../../src/index.js";
+import { getConsoleLog, mockConsoleLog } from "./helper.js";
+
+describe("Placeholders", () => {
+  beforeEach(() => {
+    mockConsoleLog(true, false);
+  });
+
+  test("It supports adding custom placeholders", (): void => {
+    const logger = new Logger({
+      type: "pretty",
+      prettyLogTemplate: "{{custom}} ",
+      overwrite: {
+        addPlaceholders: (logObjMeta: IMeta, placeholderValues: Record<string, string>) => {
+          placeholderValues["custom"] = "test";
+        },
+      },
+    });
+    logger.silly("message");
+    expect(getConsoleLog()).toMatch(/test.+message/);
+    expect(getConsoleLog()).not.toContain("{{custom}}");
+  });
+});


### PR DESCRIPTION
This PR enables the support of custom placeholders in the `prettyLogTemplate` string. The placeholders can be defined, be setting the `overwrite.addPlaceholders` function. For example to define the placeholder `{{custom}}`, add following method; 
```javascript
overwrite: {
  addPlaceholders: (logObjMeta: IMeta, placeholderValues: Record<string, string>) => {
    placeholderValues["custom"] = "test";
  },
}
```