### PR TITLE
fix nodejs environment usage in browser environments for v4.8.5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
     // style only for blink browsers
     settings.stylePrettyLogs = settings.stylePrettyLogs && isBrowser && !isBrowserBlinkEngine ? false : settings.stylePrettyLogs;
 
-    super(isBrowser && typeof('process') === 'undefined' ? BrowserRuntime : NodeRuntime, settings, logObj, isSafari ? 4 : 5);
+    super(isBrowser && typeof(process) === 'undefined' ? BrowserRuntime : NodeRuntime, settings, logObj, isSafari ? 4 : 5);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
     // style only for blink browsers
     settings.stylePrettyLogs = settings.stylePrettyLogs && isBrowser && !isBrowserBlinkEngine ? false : settings.stylePrettyLogs;
 
-    super(NodeRuntime, settings, logObj, isSafari ? 4 : 5);
+    super(isBrowser && typeof('process') === 'undefined' ? BrowserRuntime : NodeRuntime, settings, logObj, isSafari ? 4 : 5);
   }
 
   /**

--- a/src/runtime/nodejs/index.ts
+++ b/src/runtime/nodejs/index.ts
@@ -34,7 +34,7 @@ export interface IMeta extends IMetaStatic {
 
 const meta: IMetaStatic = {
   runtime: "Nodejs",
-  runtimeVersion: (typeof process != 'undefined') ? process.version : null,
+  runtimeVersion: (typeof process !== 'undefined') ? process.version : null,
   hostname: hostname ? hostname() : null,
 };
 

--- a/src/runtime/nodejs/index.ts
+++ b/src/runtime/nodejs/index.ts
@@ -34,8 +34,8 @@ export interface IMeta extends IMetaStatic {
 
 const meta: IMetaStatic = {
   runtime: "Nodejs",
-  runtimeVersion: process.version,
-  hostname: hostname(),
+  runtimeVersion: (typeof process != 'undefined') ? process.version : null,
+  hostname: hostname ? hostname() : null,
 };
 
 export function getMeta(


### PR DESCRIPTION
as the NodeJS environment is imported by default, and tries to reference process and hostname(), this fails in a browser. Also it seems to default to always construct with the NodeJS Environment instances. note this pr is against the development branch.
NOTE, if using webpack this release requires disabling;
```
 resolve: {
               fallback: { 
                "os": false, 
                "util": false,
                "path": false,
            }
        },
```