### PR TITLE
Fix missing import extension

### DIFF
--- a/src/runtime/browser/util.inspect.polyfil.ts
+++ b/src/runtime/browser/util.inspect.polyfil.ts
@@ -1,4 +1,4 @@
-import { InspectOptions } from "./InspectOptions.interface";
+import { InspectOptions } from "./InspectOptions.interface.js";
 import { prettyLogStyles } from "../../prettyLogStyles.js";
 import { jsonStringifyRecursive } from "./helper.jsonStringifyRecursive.js";
 


### PR DESCRIPTION
Part of https://github.com/fullstack-build/tslog/issues/250
May be worth setting `moduleResolution` to `NodeNext` (If all of your dependencies are compliant) in your tsconfig and TSC will emit errors when you are missing any file extensions.