### PR TITLE
handle fields which cannot be accessed gracefully

### DIFF
--- a/src/BaseLogger.ts
+++ b/src/BaseLogger.ts
@@ -213,7 +213,13 @@ export class BaseLogger<LogObj> {
       return Object.getOwnPropertyNames(source).reduce((o, prop) => {
         o[prop] = keys.includes(this.settings?.maskValuesOfKeysCaseInsensitive !== true ? prop : prop.toLowerCase())
           ? this.settings.maskPlaceholder
-          : this._recursiveCloneAndMaskValuesOfKeys((source as Record<string, unknown>)[prop], keys, seen);
+          : (()=>{
+            try{
+              return this._recursiveCloneAndMaskValuesOfKeys((source as Record<string, unknown>)[prop], keys, seen);
+            }catch(e){
+              return null;
+            }
+        })();
         return o;
       }, baseObject) as T;
     } else {

--- a/src/runtime/browser/index.ts
+++ b/src/runtime/browser/index.ts
@@ -62,8 +62,8 @@ export function getCallerStackFrame(stackDepthLevel: number, error: Error = Erro
 }
 
 export function getErrorTrace(error: Error): IStackFrame[] {
-  return (error as Error)?.stack
-    ?.split("\n")
+  return ((error as Error)?.stack
+    ?.split("\n") ?? [])
     ?.filter((line: string) => !line.includes("Error: "))
     ?.reduce((result: IStackFrame[], line: string) => {
       result.push(stackLineToStackFrame(line));


### PR DESCRIPTION
in case an object is passed for logging, but contains properties from a different security context (e.g. an iframe which is loaded from another domain), handle these fields gracefully