### PR TITLE
Expose default loglevels

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ To ensure optimal performance in production, we recommend modifying these settin
 
 ### Default log level
 
-`tslog` comes with default log level `0: silly`, `1: trace`, `2: debug`, `3: info`, `4: warn`, `5: error`, `6: fatal`.
+`tslog` comes with default log levels (`DefaultLogLevels`): `0: silly`, `1: trace`, `2: debug`, `3: info`, `4: warn`, `5: error`, `6: fatal`.
 
 > **Tip:** Each logging method has a return type, which is a _JSON_ representation of the log message (`ILogObj`).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -212,7 +212,7 @@ To ensure optimal performance in production, we recommend modifying these settin
 
 ### Default log level
 
-`tslog` comes with default log level `0: silly`, `1: trace`, `2: debug`, `3: info`, `4: warn`, `5: error`, `6: fatal`.
+`tslog` comes with default log levels (`DefaultLogLevels`): `0: silly`, `1: trace`, `2: debug`, `3: info`, `4: warn`, `5: error`, `6: fatal`.
 
 > **Tip:** Each logging method has a return type, which is a _JSON_ representation of the log message (`ILogObj`).
 
@@ -379,7 +379,7 @@ Output:
 #### minLevel
 
 You can ignore every log message from being processed until a certain severity.
-Default severities are:
+Default severities (`DefaultLogLevels`) are:
 `0: silly`, `1: trace`, `2: debug`, `3: info`, `4: warn`, `5: error`, `6: fatal`
 
 ```typescript

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -4,6 +4,16 @@ import { ILogObj, ILogObjMeta, ISettingsParam } from "./interfaces.js";
 export * from "./interfaces.js";
 export * from "./BaseLogger.js";
 
+export enum DefaultLogLevels {
+  SILLY = 0,
+  TRACE = 1,
+  DEBUG = 2,
+  INFO = 3,
+  WARN = 4,
+  ERROR = 5,
+  FATAL = 6,
+}
+
 export class Logger<LogObj> extends BaseLogger<LogObj> {
   constructor(settings?: ISettingsParam<LogObj>, logObj?: LogObj) {
     const isBrowser = ![typeof window, typeof document].includes("undefined");
@@ -34,7 +44,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public silly(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(0, "SILLY", ...args);
+    return super.log(DefaultLogLevels.SILLY, "SILLY", ...args);
   }
 
   /**
@@ -42,7 +52,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public trace(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(1, "TRACE", ...args);
+    return super.log(DefaultLogLevels.TRACE, "TRACE", ...args);
   }
 
   /**
@@ -50,7 +60,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public debug(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(2, "DEBUG", ...args);
+    return super.log(DefaultLogLevels.DEBUG, "DEBUG", ...args);
   }
 
   /**
@@ -58,7 +68,8 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public info(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(3, "INFO", ...args);
+    // TODO: here
+    return super.log(DefaultLogLevels.INFO, "INFO", ...args);
   }
 
   /**
@@ -66,7 +77,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public warn(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(4, "WARN", ...args);
+    return super.log(DefaultLogLevels.WARN, "WARN", ...args);
   }
 
   /**
@@ -74,7 +85,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public error(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(5, "ERROR", ...args);
+    return super.log(DefaultLogLevels.ERROR, "ERROR", ...args);
   }
 
   /**
@@ -82,7 +93,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public fatal(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(6, "FATAL", ...args);
+    return super.log(DefaultLogLevels.FATAL, "FATAL", ...args);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,16 @@ declare global {
   }
 }
 
+export enum DefaultLogLevels {
+  SILLY = 0,
+  TRACE = 1,
+  DEBUG = 2,
+  INFO = 3,
+  WARN = 4,
+  ERROR = 5,
+  FATAL = 6,
+}
+
 export class Logger<LogObj> extends BaseLogger<LogObj> {
   constructor(settings?: ISettingsParam<LogObj>, logObj?: LogObj) {
     const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
@@ -37,7 +47,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public silly(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(0, "SILLY", ...args);
+    return super.log(DefaultLogLevels.SILLY, "SILLY", ...args);
   }
 
   /**
@@ -45,7 +55,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public trace(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(1, "TRACE", ...args);
+    return super.log(DefaultLogLevels.TRACE, "TRACE", ...args);
   }
 
   /**
@@ -53,7 +63,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public debug(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(2, "DEBUG", ...args);
+    return super.log(DefaultLogLevels.DEBUG, "DEBUG", ...args);
   }
 
   /**
@@ -61,7 +71,8 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public info(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(3, "INFO", ...args);
+    // TODO: here
+    return super.log(DefaultLogLevels.INFO, "INFO", ...args);
   }
 
   /**
@@ -69,7 +80,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public warn(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(4, "WARN", ...args);
+    return super.log(DefaultLogLevels.WARN, "WARN", ...args);
   }
 
   /**
@@ -77,7 +88,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public error(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(5, "ERROR", ...args);
+    return super.log(DefaultLogLevels.ERROR, "ERROR", ...args);
   }
 
   /**
@@ -85,7 +96,7 @@ export class Logger<LogObj> extends BaseLogger<LogObj> {
    * @param args  - Multiple log attributes that should be logged out.
    */
   public fatal(...args: unknown[]): (LogObj & ILogObjMeta) | undefined {
-    return super.log(6, "FATAL", ...args);
+    return super.log(DefaultLogLevels.FATAL, "FATAL", ...args);
   }
 
   /**


### PR DESCRIPTION
`tslog` comes with some default log levels for `info`/`warn`/etc.

The problem is that if you're using tslog with custom log severities, things like `log.info` may stop working and outputs nothing. See for example below where I have a custom severity that sets `INFO=9`

```ts
const log: Logger<ILogObj> = new Logger({
  minLevel: MyCustomSeverity.INFO, // imagine MyCustomSeverity.INFO = 9
});
log.info("foo"); // this stop working because internally it uses `DefaultLogLevels.INFO = 3` and 3<9
```

To solve this problem, I have to build a mapping from my custom severity levels to the `tslog` severities so that my code can look like

```ts
const log: Logger<ILogObj> = new Logger({
  minLevel: mapSeverities(MyCustomSeverity.INFO) // maps 9 -> 3
});
```

However, to create the `mapSeverity` function, it would be nice to have `DefaultLogLevels` exposed as an enum from this library

## Should this PR be merged

Adding an `enum` does increase the library size by a few lines of code. If every byte matters, you could argue this isn't worth it for a feature not everybody needs.

I think just the existence of this PR that explains the issue and shows the code may be enough to unblock people who can copy-paste this enum into their own code (and can link to this PR if they want share context on where the enum came from and why it's needed)