### PR TITLE
Add missing `fileNameWithLine`

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,6 +20,7 @@ export interface IPrettyLogStyles {
   dateIsoStr?: TStyle;
   logLevelName?: TStyle;
   fileName?: TStyle;
+  fileNameWithLine?: TStyle;
   filePath?: TStyle;
   fileLine?: TStyle;
   filePathWithLine?: TStyle;
@@ -82,27 +83,7 @@ export interface ISettings<LogObj> extends ISettingsParam<LogObj> {
   prettyErrorLoggerNameDelimiter: string;
   stylePrettyLogs: boolean;
   prettyLogTimeZone: "UTC" | "local";
-  prettyLogStyles: {
-    yyyy?: TStyle;
-    mm?: TStyle;
-    dd?: TStyle;
-    hh?: TStyle;
-    MM?: TStyle;
-    ss?: TStyle;
-    ms?: TStyle;
-    dateIsoStr?: TStyle;
-    logLevelName?: TStyle;
-    fileName?: TStyle;
-    fileNameWithLine?: TStyle;
-    filePath?: TStyle;
-    fileLine?: TStyle;
-    filePathWithLine?: TStyle;
-    name?: TStyle;
-    nameWithDelimiterPrefix?: TStyle;
-    nameWithDelimiterSuffix?: TStyle;
-    errorName?: TStyle;
-    errorMessage?: TStyle;
-  };
+  prettyLogStyles: IPrettyLogStyles;
   prettyInspectOptions: InspectOptions;
   metaProperty: string;
   maskPlaceholder: string;


### PR DESCRIPTION
`fileNameWithLine` is meant to be part of the settings as per the docs, but it was accidentally omitted in the type definition.

To avoid this kind of error, I also changed it so that the `prettyLogStyles` is not duplicated in two places to make sure they're always in sync