### PR TITLE
fix getErrorTrace

### DIFF
--- a/src/runtime/nodejs/index.ts
+++ b/src/runtime/nodejs/index.ts
@@ -62,12 +62,12 @@ export function getCallerStackFrame(stackDepthLevel: number, error: Error = Erro
 }
 
 export function getErrorTrace(error: Error): IStackFrame[] {
-  return (error as Error)?.stack?.split("\n")?.reduce((result: IStackFrame[], line: string) => {
+  return ((error as Error)?.stack?.split("\n") ?? []).reduce((result: IStackFrame[], line: string) => {
     if (line.includes("    at ")) {
       result.push(stackLineToStackFrame(line));
     }
     return result;
-  }, []) as IStackFrame[];
+  }, []);
 }
 
 function stackLineToStackFrame(line?: string): IStackFrame {


### PR DESCRIPTION
fix `Cannot read properties of undefined (reading 'map') at prettyFormatErrorObj` .

https://github.com/fullstack-build/tslog/issues/311

