### PR TITLE
Update README.md to fix broken script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ In addition to the default log level, custom log level can be defined in the sam
 > **Tip:** Also the generic logging method (log()) returns a _JSON_ representation of the log message (`ILogObject`).
 
 ```typescript
-import { BaseLogger, ILogObjMeta, ISettingsParam, ILogObj } from "./BaseLogger";
+import { BaseLogger, ILogObjMeta, ISettingsParam } from "tslog";
 
 export class CustomLogger<LogObj> extends BaseLogger<LogObj> {
   constructor(settings?: ISettingsParam<LogObj>, logObj?: LogObj) {


### PR DESCRIPTION
The README file contained a code example that appeared to have a copy-paste issue, likely from a different context. I tested out locally to verify that the imports resolved correctly. Thought I'd PR to cover where others may try to use by example too.

Issue #315 

https://github.com/fullstack-build/tslog/blob/master/README.md?plain=1#L243

![broken-example](https://github.com/user-attachments/assets/eb262cd6-67b3-43be-8d33-bdda4c191e7f)

![working-example](https://github.com/user-attachments/assets/88de1c0d-8bf1-4b87-97de-3b6d1adc2184)
