### PR TITLE
Update README.md to fix incorrect example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ const childLogger = logger.getSubLogger({
 });
 childLogger.info("child1 message");
 // Output:
-// main-prefix parent-prefix child1-prefix MainLogger message
+// main-prefix parent-prefix child1-prefix child1 message
 
 const grandchildLogger = childLogger.getSubLogger({
   prefix: ["grandchild1-prefix"],


### PR DESCRIPTION
This PR corrects the example output for prefixing logs. In the previous example, the output for the `childLogger` was mistakenly documented as `MainLogger` instead of `child1`.