### PR TITLE
Fix BROWSER_PATH_REGEX

### DIFF
--- a/src/BaseLogger.ts
+++ b/src/BaseLogger.ts
@@ -707,7 +707,7 @@ type RuntimeMeta = IMeta & {
   browser?: string;
 };
 
-const BROWSER_PATH_REGEX = /(?:(?:file|https?|global code|[^@]+)@)?(?:file:)?((?:\/[^:/]+){2,})(?::(\d+))?(?::(\d+))?/;
+const BROWSER_PATH_REGEX = /(?:(?:https?|file|global code):\/\/[^\s)]+\/)?((?:\/|[A-Za-z]:\/)[^:\s)]+?\.\w+(?:\?\S+)?):(\d+):(\d+)/;
 
 const runtime = createLoggerEnvironment();
 


### PR DESCRIPTION
The regex could not properly capture pathes on Windows filesystems. The regex only captured the path up to the drive letter.