### PR TITLE
fix: make _extend method use shallow copy

### DIFF
--- a/src/internal/util.inspect.polyfill.ts
+++ b/src/internal/util.inspect.polyfill.ts
@@ -378,7 +378,7 @@ function reduceToSingleString(output: string[], base: string, braces: string[]):
 }
 
 function _extend(origin: object, add: object): object {
-  const typedOrigin = { ...origin } as { [key: string]: unknown };
+  const typedOrigin = origin as { [key: string]: unknown };
   // Don't do anything if add isn't an object
   if (!add || !isObject(add)) return origin;
 


### PR DESCRIPTION
after use polyfill to all environment, at node.js it couldn't override prettyInspectOptions to ctx.

fix: https://github.com/fullstack-build/tslog/issues/327